### PR TITLE
Allow multiple src globs to be passed to WP POT

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -41,7 +41,10 @@ const cli = meow(helpText, {
     writeFile: true,
     filePaths: true
   },
-  boolean: ['write-file', 'file-paths']
+  boolean: ['write-file', 'file-paths'],
+  src: {
+    isMultiple: true
+  }
 });
 
 if (cli.flags.filePaths === false) {

--- a/test/fixtures/multi-functions.php
+++ b/test/fixtures/multi-functions.php
@@ -1,0 +1,2 @@
+<?php
+__('Multi function return string', 'testdomain');

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@
 const execa = require('execa');
 const os = require('os');
 const fs = require('fs');
+const assert = require('assert');
 
 const testHelper = require('./test-helper');
 const fixturePath = 'test/fixtures/valid-functions.php';
@@ -27,6 +28,22 @@ describe('Test CLI output', function () {
       try {
         const potContents = fs.readFileSync(tempPot).toString();
         testHelper.testValidFunctions(potContents, fixturePath);
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should write pot file to dest-file path with multiple src flags', function (done) {
+    const test = assert;
+    const tempPot = `${os.tmpdir()}/test.pot`;
+    const multiFixturePath = 'test/fixtures/multi-functions.php';
+    execa('./cli.js', ['--dest-file', tempPot, '--src', fixturePath, '--src', multiFixturePath]).then(function () {
+      try {
+        const potContents = fs.readFileSync(tempPot).toString();
+        testHelper.testValidFunctions(potContents, fixturePath);
+        test(testHelper.verifyLanguageBlock(potContents, false, multiFixturePath + ':2', 'Multi function return string', false, false));
         done();
       } catch (e) {
         done(e);


### PR DESCRIPTION
When meow allows a flag to be set multiple times it automatically converts the input into an array, which means you can now pass multiple globs to WP POT using `wp-pot --src path1 --src path2 --src path3`.

The reason this change is needed is that the technique described https://github.com/wp-pot/wp-pot-cli/issues/17#issuecomment-351395090 does not work (at least in the latest version of WP POT / WP POT CLI), and the string containing an array is always a string.

Unit test has been added for this use case, and linting passes 👍